### PR TITLE
Fix support monitor

### DIFF
--- a/config/com.nachocove.beta1.DailyMonitors.template
+++ b/config/com.nachocove.beta1.DailyMonitors.template
@@ -11,7 +11,7 @@ http://www.apple.com/DTDs/PropertyList-1.0.dtd >
         <string>python2.7</string>
         <string>monitor.py</string>
         <string>--config</string>
-        <string>monitor_beta1.cfg</string>
+        <string>../config/monitor_beta1.cfg</string>
         <string>--after</string>
         <string>last</string>
         <string>--daily</string>

--- a/config/com.nachocove.beta1.SupportMonitor.template
+++ b/config/com.nachocove.beta1.SupportMonitor.template
@@ -11,7 +11,7 @@ http://www.apple.com/DTDs/PropertyList-1.0.dtd >
         <string>python2.7</string>
         <string>monitor.py</string>
         <string>--config</string>
-        <string>support_beta1.cfg</string>
+        <string>../config/support_beta1.cfg</string>
         <string>--after</string>
         <string>last</string>
         <string>--before</string>

--- a/config/com.nachocove.dev.DailyMonitors.template
+++ b/config/com.nachocove.dev.DailyMonitors.template
@@ -11,7 +11,7 @@ http://www.apple.com/DTDs/PropertyList-1.0.dtd >
         <string>python2.7</string>
         <string>monitor.py</string>
         <string>--config</string>
-        <string>monitor_dev.cfg</string>
+        <string>../config/monitor_dev.cfg</string>
         <string>--after</string>
         <string>last</string>
         <string>--daily</string>

--- a/config/support_beta1.cfg
+++ b/config/support_beta1.cfg
@@ -1,6 +1,7 @@
 [aws]
 access_key_id = AKIAIWO5PADDLTAPVMDA
 secret_access_key = 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
+prefix = beta
 
 [hockeyapp]
 app_id = 44dae4a6ae9134930c64c623d5023ac4

--- a/scripts/misc/support.py
+++ b/scripts/misc/support.py
@@ -5,7 +5,7 @@ import hashlib
 class SupportEvent:
     def __init__(self, event):
         self.client = event['client']
-        self.timestamp = event['timestamp']['iso']
+        self.timestamp = str(event['timestamp'])
         self.params = json.loads(event['support'])
         if self.params is None:
             # There are some bad SUPPORT events in telemetry. They were


### PR DESCRIPTION
Support monitor is not running on my Mac mini. Need a few fixes:
- Update the config to the right path. ['iso'] was from Parse. The new way is to convert the timestamp to str.
- Add prefix to the support config.
