### PR TITLE
Make a CrashInfoFactory that creates the right CrashInfo subclass based ...

### DIFF
--- a/scripts/monitors/monitor_hockeyapp.py
+++ b/scripts/monitors/monitor_hockeyapp.py
@@ -116,6 +116,9 @@ class CrashInfoIos(CrashInfo):
             return match.group('crash_utc')
         return None  # somehow cannot find the crash time in the raw crash log
 
+class CrashInfoUnknownPlatformException(Exception):
+    pass
+
 def CrashInfoFactory(ha_crash_obj, conn):
     """
     Create a crashinfo subclass based on the crash-group
@@ -131,7 +134,7 @@ def CrashInfoFactory(ha_crash_obj, conn):
     if platform == 'iOS':
         return CrashInfoIos(ha_crash_obj, conn)
     else:
-        raise ValueError("Unsupported (unimplemented) crash platform %s" % platform)
+        raise CrashInfoUnknownPlatformException("Unsupported (unimplemented) crash platform %s" % platform)
 
 class MonitorHockeyApp(Monitor):
     def __init__(self, conn, start=None, end=None, ha_app_obj=None):
@@ -170,7 +173,10 @@ class MonitorHockeyApp(Monitor):
                 # the DynamoDB connection may have time out. So, create
                 # a new one
                 conn = self.clone_connection(self.conn)
-                self.crashes.append(CrashInfoFactory(crash, conn))
+                try:
+                    self.crashes.append(CrashInfoFactory(crash, conn))
+                except CrashInfoUnknownPlatformException as e:
+                    self.logger.error('Could not analyze crash: %s (SKIPPING)' % e)
 
     def report(self, summary, **kwargs):
         summary.add_entry('Crash count', str(len(self.crashes)))

--- a/scripts/monitors/monitor_hockeyapp.py
+++ b/scripts/monitors/monitor_hockeyapp.py
@@ -116,6 +116,22 @@ class CrashInfoIos(CrashInfo):
             return match.group('crash_utc')
         return None  # somehow cannot find the crash time in the raw crash log
 
+def CrashInfoFactory(ha_crash_obj, conn):
+    """
+    Create a crashinfo subclass based on the crash-group
+
+    :param ha_crash_obj: a crash object
+    :type ha_crash_obj: HockeyApp.crash.Crash()
+    :param conn: an aws connection
+    :type conn: AWS()
+    :return:
+    """
+    assert(isinstance(ha_crash_obj, HockeyApp.crash.Crash))
+    platform = ha_crash_obj.crash_group_obj.app_obj.platform
+    if platform == 'iOS':
+        return CrashInfoIos(ha_crash_obj, conn)
+    else:
+        raise ValueError("Unsupported (unimplemented) crash platform %s" % platform)
 
 class MonitorHockeyApp(Monitor):
     def __init__(self, conn, start=None, end=None, ha_app_obj=None):
@@ -148,14 +164,13 @@ class MonitorHockeyApp(Monitor):
                 # Get all crashes that uploaded within the time window
                 if not self._within_window(UtcDateTime(crash.created_at)):
                     continue
-                self.logger.debug('  Analyzing crash %s (in crash group %s)',
-                                  crash.crash_id, crash_group.crash_group_id)
+                self.logger.debug('  Analyzing crash %s (in crash group %s, platform %s)',
+                                  crash.crash_id, crash_group.crash_group_id, crash_group.app_obj.platform)
                 # HockeyApp is quite slow. By the time we get here,
                 # the DynamoDB connection may have time out. So, create
                 # a new one
                 conn = self.clone_connection(self.conn)
-                # TODO - parse the platform and instantiate the right class of objects
-                self.crashes.append(CrashInfoIos(crash, conn))
+                self.crashes.append(CrashInfoFactory(crash, conn))
 
     def report(self, summary, **kwargs):
         summary.add_entry('Crash count', str(len(self.crashes)))


### PR DESCRIPTION
...on the crash. Uses the crash->group->app->platform currently. Also, currently only iOS is supported. At least we'll get proper error messages when we add more crashes

example:

2014-11-21 16:41:06.227  INFO     Query crash logs...
2014-11-21 16:41:27.690  DEBUG      Analyzing crash 2195436681 (in crash group 23353169, platform iOS)
2014-11-21 16:41:46.915  DEBUG        device id = NchoFA153954X4D45X4524XB091X
2014-11-21 17:05:37.646  DEBUG        client = us-east-1:c5d1892a-aa21-4d64-abd4-f188f7b7dffe
2014-11-21 17:05:37.652  DEBUG        crash time = 2014-11-21T18:30:27Z
