### PR TITLE
When there's no telemetry found, look to see if there are 'backlog' support events

### DIFF
--- a/scripts/misc/support.py
+++ b/scripts/misc/support.py
@@ -27,6 +27,8 @@ class SupportEvent:
         msg += 'client: %s\n' % self.client
         return msg
 
+    def __str__(self):
+        return self.display()
 
 class SupportRequestEvent(SupportEvent):
     def __init__(self, event):
@@ -64,6 +66,25 @@ class SupportSha256EmailAddressEvent(SupportEvent):
     def parse(event):
         try:
             return SupportSha256EmailAddressEvent(event)
+        except KeyError:
+            return None
+
+
+class SupportBackLogEvent(SupportEvent):
+    def __init__(self, event):
+        SupportEvent.__init__(self, event)
+        self.num_events = self.params['num_events']
+        self.oldest_event = self.params['oldest_event']
+
+    def display(self):
+        msg = SupportEvent.display(self)
+        msg += 'num_events: %s\noldest_event: %s\n' % (self.num_events, self.oldest_event)
+        return msg
+
+    @staticmethod
+    def parse(event):
+        try:
+            return SupportBackLogEvent(event)
         except KeyError:
             return None
 


### PR DESCRIPTION
so we can write a better explanation for why we couldn't process this push.
Also fixed a minor sorting bug in the pinger-push sorted list.
